### PR TITLE
Create Newton's Third Law.md

### DIFF
--- a/Newton's Third Law.md
+++ b/Newton's Third Law.md
@@ -1,0 +1,25 @@
+# Newton's Third Law
+
+In physics, the concept of **reactive force** typically arises from Newton's Third Law, which states that "for every action, there is an equal and opposite reaction." However, when dealing with fundamental forces like the **strong force** and **weak force**, the interpretation of reactive forces becomes more subtle due to the nature of these interactions.
+
+### **Reactive Force in the Strong Force (Quantum Chromodynamics - QCD)**
+- The **strong force** is responsible for binding quarks together to form protons, neutrons, and other hadrons, as well as holding protons and neutrons together in atomic nuclei.
+- This force is mediated by **gluon exchange** and follows **Quantum Chromodynamics (QCD)**.
+- Unlike classical forces, the strong force does not have a simple Newtonian reaction force because the interactions involve quantum fields rather than direct particle-to-particle force interactions.
+- However, **color confinement** and the **asymptotic freedom** of quarks suggest a form of reaction: when quarks move apart, the gluonic field pulls them back with an increasing force, akin to a spring-like potential. If enough energy is applied, the energy converts into new quark-antiquark pairs rather than creating a classical reaction force.
+
+### **Reactive Force in the Weak Force (Electroweak Interaction)**
+- The **weak force** governs radioactive decay (e.g., beta decay) and is mediated by the **W and Z bosons**.
+- Since weak interactions involve the transformation of particles rather than direct force-mediated attraction/repulsion, the concept of a classical reaction force is less applicable.
+- However, one can argue that in weak interactions, the conservation of **energy, momentum, and angular momentum** ensures a form of "reaction." For example:
+  - In **beta decay**, a neutron decays into a proton, an electron, and an antineutrino. The emitted electron and antineutrino ensure momentum conservation, behaving as a recoil effect.
+  - In weak interactions involving W-boson exchange, the momentum transfer between initial and final particles plays a role similar to a reaction force.
+
+### **Key Takeaways**
+- **Strong Force**: The gluonic field acts as a "reactive force" by preventing quarks from separating indefinitely, leading to quark confinement.
+- **Weak Force**: The "reaction" is not a direct force but is observed through conservation laws (e.g., momentum recoil in particle decays).
+
+In summary, while classical reactive forces apply to macroscopic physics, fundamental forces like the strong and weak interactions follow quantum field theory principles, where reactions are governed by energy-momentum conservation rather than simple force pairs.
+
+
+## 


### PR DESCRIPTION
```markdown
# Newton's Third Law

In physics, the concept of **reactive force** typically arises from Newton's Third Law, which states that "for every action, there is an equal and opposite reaction." However, when dealing with fundamental forces like the **strong force** and **weak force**, the interpretation of reactive forces becomes more subtle due to the nature of these interactions.

### **Reactive Force in the Strong Force (Quantum Chromodynamics - QCD)**
- The **strong force** is responsible for binding quarks together to form protons, neutrons, and other hadrons, as well as holding protons and neutrons together in atomic nuclei.
- This force is mediated by **gluon exchange** and follows **Quantum Chromodynamics (QCD)**.
- Unlike classical forces, the strong force does not have a simple Newtonian reaction force because the interactions involve quantum fields rather than direct particle-to-particle force interactions.
- However, **color confinement** and the **asymptotic freedom** of quarks suggest a form of reaction: when quarks move apart, the gluonic field pulls them back with an increasing force, akin to a spring-like potential. If enough energy is applied, the energy converts into new quark-antiquark pairs rather than creating a classical reaction force.

### **Reactive Force in the Weak Force (Electroweak Interaction)**
- The **weak force** governs radioactive decay (e.g., beta decay) and is mediated by the **W and Z bosons**.
- Since weak interactions involve the transformation of particles rather than direct force-mediated attraction/repulsion, the concept of a classical reaction force is less applicable.
- However, one can argue that in weak interactions, the conservation of **energy, momentum, and angular momentum** ensures a form of "reaction." For example:
  - In **beta decay**, a neutron decays into a proton, an electron, and an antineutrino. The emitted electron and antineutrino ensure momentum conservation, behaving as a recoil effect.
  - In weak interactions involving W-boson exchange, the momentum transfer between initial and final particles plays a role similar to a reaction force.

### **Key Takeaways**
- **Strong Force**: The gluonic field acts as a "reactive force" by preventing quarks from separating indefinitely, leading to quark confinement.
- **Weak Force**: The "reaction" is not a direct force but is observed through conservation laws (e.g., momentum recoil in particle decays).

In summary, while classical reactive forces apply to macroscopic physics, fundamental forces like the strong and weak interactions follow quantum field theory principles, where reactions are governed by energy-momentum conservation rather than simple force pairs.


## 
```