### PR TITLE
Create f = ma.md

### DIFF
--- a/f = ma.md
+++ b/f = ma.md
@@ -1,0 +1,209 @@
+# F= MA
+
+The geodesic equation describes the motion of a free-falling particle in a curved spacetime. It is given by:
+
+\[
+\frac{d^2 x^\mu}{d\tau^2} + \Gamma^\mu_{\rho\sigma} \frac{dx^\rho}{d\tau} \frac{dx^\sigma}{d\tau} = 0
+\]
+
+where:
+- \( x^\mu \) are the spacetime coordinates of the particle,
+- \( \tau \) is the proper time,
+- \( \Gamma^\mu_{\rho\sigma} \) are the Christoffel symbols, which describe the connection coefficients of the spacetime.
+
+### 1. **Derivation from the Variational Principle**
+The geodesic equation can be derived from the principle of least action using the metric tensor \( g_{\mu\nu} \). The action for a free particle in curved spacetime is:
+
+\[
+S = \int \sqrt{ g_{\mu\nu} \frac{dx^\mu}{d\lambda} \frac{dx^\nu}{d\lambda} } \, d\lambda
+\]
+
+where \( \lambda \) is an affine parameter (usually the proper time \( \tau \) for massive particles).
+
+Minimizing this action leads to the Euler-Lagrange equations, which result in the geodesic equation.
+
+### 2. **Explicit Form in Schwarzschild Metric**
+For example, in the Schwarzschild metric:
+
+\[
+ds^2 = - \left( 1 - \frac{2GM}{r} \right) dt^2 + \left( 1 - \frac{2GM}{r} \right)^{-1} dr^2 + r^2 d\Omega^2
+\]
+
+the geodesic equations take the form:
+
+\[
+\frac{d^2 t}{d\tau^2} + \frac{2GM}{r^2} \left( 1 - \frac{2GM}{r} \right)^{-1} \frac{dr}{d\tau} \frac{dt}{d\tau} = 0
+\]
+
+\[
+\frac{d^2 r}{d\tau^2} - \frac{GM}{r^2} \left( 1 - \frac{2GM}{r} \right) + \frac{GM}{r^2} \left( \frac{dt}{d\tau} \right)^2 - r \left( \frac{d\phi}{d\tau} \right)^2 = 0
+\]
+
+\[
+\frac{d^2 \phi}{d\tau^2} + \frac{2}{r} \frac{dr}{d\tau} \frac{d\phi}{d\tau} = 0
+\]
+
+These describe the motion of a particle near a massive body.
+
+Would you like a specific application, such as photon geodesics or circular orbits?
+
+##　what happend to the mass term?
+
+In the geodesic equation:
+
+\[
+\frac{d^2 x^\mu}{d\tau^2} + \Gamma^\mu_{\rho\sigma} \frac{dx^\rho}{d\tau} \frac{dx^\sigma}{d\tau} = 0
+\]
+
+there is **no explicit mass term** because the equation describes the trajectory of a free-falling particle **independent of its mass**. This reflects the equivalence principle in General Relativity, which states that the motion of a test particle in free fall is the same regardless of its mass.
+
+### Why Doesn't the Mass Appear?
+1. **From the Euler-Lagrange Equation**  
+   The geodesic equation can be derived from the variational principle applied to the action:
+
+   \[
+   S = \int g_{\mu\nu} \dot{x}^\mu \dot{x}^\nu d\lambda
+   \]
+
+   where \( \dot{x}^\mu = \frac{dx^\mu}{d\lambda} \), and \( \lambda \) is an affine parameter (which is proper time \( \tau \) for massive particles and an arbitrary affine parameter for massless particles). Since the Lagrangian is homogeneous in velocity, the mass term cancels out when taking the Euler-Lagrange equation.
+
+2. **Normalization Condition for the Four-Velocity**  
+   The proper time \( \tau \) is related to the metric by:
+
+   \[
+   g_{\mu\nu} \frac{dx^\mu}{d\tau} \frac{dx^\nu}{d\tau} = -1
+   \]
+
+   for massive particles, or:
+
+   \[
+   g_{\mu\nu} \frac{dx^\mu}{d\lambda} \frac{dx^\nu}{d\lambda} = 0
+   \]
+
+   for massless particles (e.g., photons). The mass doesn't appear explicitly because it cancels when differentiating this constraint.
+
+3. **Equivalence Principle and Universality of Free Fall**  
+   The equation shows that geodesics are purely a property of spacetime and **do not depend on mass**. This is a direct consequence of the equivalence principle: in a local freely falling frame, gravity disappears, and all objects follow the same trajectory regardless of their mass.
+
+### What About Energy and Momentum?
+- The **energy** of a particle does depend on its mass and velocity, but in the geodesic equation, we are solving for the spacetime trajectory rather than forces or energy.
+- If we need to include mass explicitly, we use the **four-momentum** \( p^\mu = m u^\mu \), where \( u^\mu = \frac{dx^\mu}{d\tau} \) is the four-velocity. However, the geodesic equation remains mass-independent.
+
+### Summary
+- The mass cancels out due to the **affine nature of the geodesic equation**.
+- The **equivalence principle** ensures that all free-falling objects follow the same geodesics, regardless of mass.
+- If we want to track mass-dependent effects, we consider energy-momentum rather than the geodesic equation itself.
+
+Would you like an explicit derivation showing how the mass term cancels out?
+
+## yes
+
+To explicitly show why the **mass term cancels out** in the geodesic equation, let's derive it step by step.
+
+---
+
+## **Step 1: Start with the Action**
+The motion of a free particle in curved spacetime follows from the **Einstein-Hilbert action** for a point mass:
+
+\[
+S = -m \int d\tau
+\]
+
+where:
+- \( m \) is the mass of the particle,
+- \( \tau \) is the **proper time**, defined via the metric as:
+  \[
+  d\tau^2 = - g_{\mu\nu} dx^\mu dx^\nu
+  \]
+
+Alternatively, we can write the action in terms of an affine parameter \( \lambda \) (which could be proper time for massive particles, but also works for massless ones):
+
+\[
+S = -m \int \sqrt{- g_{\mu\nu} \dot{x}^\mu \dot{x}^\nu} \, d\lambda
+\]
+
+where \( \dot{x}^\mu = \frac{dx^\mu}{d\lambda} \).
+
+---
+
+## **Step 2: Derive the Euler-Lagrange Equations**
+The Lagrangian is:
+
+\[
+\mathcal{L} = -m \sqrt{- g_{\mu\nu} \dot{x}^\mu \dot{x}^\nu}
+\]
+
+The Euler-Lagrange equation is:
+
+\[
+\frac{d}{d\lambda} \left( \frac{\partial \mathcal{L}}{\partial \dot{x}^\mu} \right) - \frac{\partial \mathcal{L}}{\partial x^\mu} = 0
+\]
+
+First, compute:
+
+\[
+\frac{\partial \mathcal{L}}{\partial \dot{x}^\mu} = -m \frac{g_{\mu\nu} \dot{x}^\nu}{\sqrt{- g_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma}}
+\]
+
+Now, differentiating with respect to \( \lambda \):
+
+\[
+\frac{d}{d\lambda} \left( \frac{\partial \mathcal{L}}{\partial \dot{x}^\mu} \right) =
+\frac{d}{d\lambda} \left( -m \frac{g_{\mu\nu} \dot{x}^\nu}{\sqrt{- g_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma}} \right)
+\]
+
+Since the proper time \( \tau \) is defined such that:
+
+\[
+g_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma = -1
+\]
+
+for a massive particle, the square root term is simply \( m \), canceling out the \( m \) in the numerator. This means the Euler-Lagrange equation simplifies to:
+
+\[
+\frac{d}{d\lambda} ( g_{\mu\nu} \dot{x}^\nu ) - \frac{1}{2} g_{\alpha\beta,\mu} \dot{x}^\alpha \dot{x}^\beta = 0
+\]
+
+which, rewriting with Christoffel symbols:
+
+\[
+\frac{d\dot{x}^\mu}{d\lambda} + \Gamma^\mu_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma = 0
+\]
+
+is exactly the **geodesic equation**:
+
+\[
+\frac{d^2 x^\mu}{d\lambda^2} + \Gamma^\mu_{\rho\sigma} \frac{dx^\rho}{d\lambda} \frac{dx^\sigma}{d\lambda} = 0
+\]
+
+---
+
+## **Step 3: Why the Mass Cancels**
+- The mass \( m \) appears initially in the action but **cancels out completely** in the final equation of motion.
+- This happens because the geodesic equation is derived from a **reparameterization-invariant** action, meaning the trajectory is independent of the scale of the affine parameter.
+- Since every freely falling particle follows the same geodesics, the equation does **not depend on the particle's mass**.
+
+This result is a direct manifestation of the **equivalence principle**, which states that all objects (regardless of mass) fall in the same way in a gravitational field.
+
+---
+
+## **What About Massless Particles (e.g., Photons)?**
+For massless particles like photons:
+- The proper time \( \tau \) is not well-defined because \( ds^2 = 0 \).
+- Instead, we use an **arbitrary affine parameter** \( \lambda \) in the geodesic equation:
+
+  \[
+  g_{\mu\nu} \frac{dx^\mu}{d\lambda} \frac{dx^\nu}{d\lambda} = 0
+  \]
+
+  which ensures the motion remains consistent with the geodesic equation.
+
+---
+
+## **Final Answer:**
+The mass term cancels in the geodesic equation because:
+1. The **Euler-Lagrange formulation** of the action naturally removes the mass after differentiation.
+2. The equation is **invariant under affine reparameterization**.
+3. The **equivalence principle** ensures all objects move along the same geodesics, regardless of mass.
+
+Thus, the geodesic equation applies **equally** to **all** particles, whether massive or massless.


### PR DESCRIPTION
```markdown
# F= MA

The geodesic equation describes the motion of a free-falling particle in a curved spacetime. It is given by:

\[
\frac{d^2 x^\mu}{d\tau^2} + \Gamma^\mu_{\rho\sigma} \frac{dx^\rho}{d\tau} \frac{dx^\sigma}{d\tau} = 0
\]

where:
- \( x^\mu \) are the spacetime coordinates of the particle,
- \( \tau \) is the proper time,
- \( \Gamma^\mu_{\rho\sigma} \) are the Christoffel symbols, which describe the connection coefficients of the spacetime.

### 1. **Derivation from the Variational Principle**
The geodesic equation can be derived from the principle of least action using the metric tensor \( g_{\mu\nu} \). The action for a free particle in curved spacetime is:

\[
S = \int \sqrt{ g_{\mu\nu} \frac{dx^\mu}{d\lambda} \frac{dx^\nu}{d\lambda} } \, d\lambda
\]

where \( \lambda \) is an affine parameter (usually the proper time \( \tau \) for massive particles).

Minimizing this action leads to the Euler-Lagrange equations, which result in the geodesic equation.

### 2. **Explicit Form in Schwarzschild Metric**
For example, in the Schwarzschild metric:

\[
ds^2 = - \left( 1 - \frac{2GM}{r} \right) dt^2 + \left( 1 - \frac{2GM}{r} \right)^{-1} dr^2 + r^2 d\Omega^2
\]

the geodesic equations take the form:

\[
\frac{d^2 t}{d\tau^2} + \frac{2GM}{r^2} \left( 1 - \frac{2GM}{r} \right)^{-1} \frac{dr}{d\tau} \frac{dt}{d\tau} = 0
\]

\[
\frac{d^2 r}{d\tau^2} - \frac{GM}{r^2} \left( 1 - \frac{2GM}{r} \right) + \frac{GM}{r^2} \left( \frac{dt}{d\tau} \right)^2 - r \left( \frac{d\phi}{d\tau} \right)^2 = 0
\]

\[
\frac{d^2 \phi}{d\tau^2} + \frac{2}{r} \frac{dr}{d\tau} \frac{d\phi}{d\tau} = 0
\]

These describe the motion of a particle near a massive body.

Would you like a specific application, such as photon geodesics or circular orbits?

##　what happend to the mass term?

In the geodesic equation:

\[
\frac{d^2 x^\mu}{d\tau^2} + \Gamma^\mu_{\rho\sigma} \frac{dx^\rho}{d\tau} \frac{dx^\sigma}{d\tau} = 0
\]

there is **no explicit mass term** because the equation describes the trajectory of a free-falling particle **independent of its mass**. This reflects the equivalence principle in General Relativity, which states that the motion of a test particle in free fall is the same regardless of its mass.

### Why Doesn't the Mass Appear?
1. **From the Euler-Lagrange Equation**  
   The geodesic equation can be derived from the variational principle applied to the action:

   \[
   S = \int g_{\mu\nu} \dot{x}^\mu \dot{x}^\nu d\lambda
   \]

   where \( \dot{x}^\mu = \frac{dx^\mu}{d\lambda} \), and \( \lambda \) is an affine parameter (which is proper time \( \tau \) for massive particles and an arbitrary affine parameter for massless particles). Since the Lagrangian is homogeneous in velocity, the mass term cancels out when taking the Euler-Lagrange equation.

2. **Normalization Condition for the Four-Velocity**  
   The proper time \( \tau \) is related to the metric by:

   \[
   g_{\mu\nu} \frac{dx^\mu}{d\tau} \frac{dx^\nu}{d\tau} = -1
   \]

   for massive particles, or:

   \[
   g_{\mu\nu} \frac{dx^\mu}{d\lambda} \frac{dx^\nu}{d\lambda} = 0
   \]

   for massless particles (e.g., photons). The mass doesn't appear explicitly because it cancels when differentiating this constraint.

3. **Equivalence Principle and Universality of Free Fall**  
   The equation shows that geodesics are purely a property of spacetime and **do not depend on mass**. This is a direct consequence of the equivalence principle: in a local freely falling frame, gravity disappears, and all objects follow the same trajectory regardless of their mass.

### What About Energy and Momentum?
- The **energy** of a particle does depend on its mass and velocity, but in the geodesic equation, we are solving for the spacetime trajectory rather than forces or energy.
- If we need to include mass explicitly, we use the **four-momentum** \( p^\mu = m u^\mu \), where \( u^\mu = \frac{dx^\mu}{d\tau} \) is the four-velocity. However, the geodesic equation remains mass-independent.

### Summary
- The mass cancels out due to the **affine nature of the geodesic equation**.
- The **equivalence principle** ensures that all free-falling objects follow the same geodesics, regardless of mass.
- If we want to track mass-dependent effects, we consider energy-momentum rather than the geodesic equation itself.

Would you like an explicit derivation showing how the mass term cancels out?

## yes

To explicitly show why the **mass term cancels out** in the geodesic equation, let's derive it step by step.

---

## **Step 1: Start with the Action**
The motion of a free particle in curved spacetime follows from the **Einstein-Hilbert action** for a point mass:

\[
S = -m \int d\tau
\]

where:
- \( m \) is the mass of the particle,
- \( \tau \) is the **proper time**, defined via the metric as:
  \[
  d\tau^2 = - g_{\mu\nu} dx^\mu dx^\nu
  \]

Alternatively, we can write the action in terms of an affine parameter \( \lambda \) (which could be proper time for massive particles, but also works for massless ones):

\[
S = -m \int \sqrt{- g_{\mu\nu} \dot{x}^\mu \dot{x}^\nu} \, d\lambda
\]

where \( \dot{x}^\mu = \frac{dx^\mu}{d\lambda} \).

---

## **Step 2: Derive the Euler-Lagrange Equations**
The Lagrangian is:

\[
\mathcal{L} = -m \sqrt{- g_{\mu\nu} \dot{x}^\mu \dot{x}^\nu}
\]

The Euler-Lagrange equation is:

\[
\frac{d}{d\lambda} \left( \frac{\partial \mathcal{L}}{\partial \dot{x}^\mu} \right) - \frac{\partial \mathcal{L}}{\partial x^\mu} = 0
\]

First, compute:

\[
\frac{\partial \mathcal{L}}{\partial \dot{x}^\mu} = -m \frac{g_{\mu\nu} \dot{x}^\nu}{\sqrt{- g_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma}}
\]

Now, differentiating with respect to \( \lambda \):

\[
\frac{d}{d\lambda} \left( \frac{\partial \mathcal{L}}{\partial \dot{x}^\mu} \right) =
\frac{d}{d\lambda} \left( -m \frac{g_{\mu\nu} \dot{x}^\nu}{\sqrt{- g_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma}} \right)
\]

Since the proper time \( \tau \) is defined such that:

\[
g_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma = -1
\]

for a massive particle, the square root term is simply \( m \), canceling out the \( m \) in the numerator. This means the Euler-Lagrange equation simplifies to:

\[
\frac{d}{d\lambda} ( g_{\mu\nu} \dot{x}^\nu ) - \frac{1}{2} g_{\alpha\beta,\mu} \dot{x}^\alpha \dot{x}^\beta = 0
\]

which, rewriting with Christoffel symbols:

\[
\frac{d\dot{x}^\mu}{d\lambda} + \Gamma^\mu_{\rho\sigma} \dot{x}^\rho \dot{x}^\sigma = 0
\]

is exactly the **geodesic equation**:

\[
\frac{d^2 x^\mu}{d\lambda^2} + \Gamma^\mu_{\rho\sigma} \frac{dx^\rho}{d\lambda} \frac{dx^\sigma}{d\lambda} = 0
\]

---

## **Step 3: Why the Mass Cancels**
- The mass \( m \) appears initially in the action but **cancels out completely** in the final equation of motion.
- This happens because the geodesic equation is derived from a **reparameterization-invariant** action, meaning the trajectory is independent of the scale of the affine parameter.
- Since every freely falling particle follows the same geodesics, the equation does **not depend on the particle's mass**.

This result is a direct manifestation of the **equivalence principle**, which states that all objects (regardless of mass) fall in the same way in a gravitational field.

---

## **What About Massless Particles (e.g., Photons)?**
For massless particles like photons:
- The proper time \( \tau \) is not well-defined because \( ds^2 = 0 \).
- Instead, we use an **arbitrary affine parameter** \( \lambda \) in the geodesic equation:

  \[
  g_{\mu\nu} \frac{dx^\mu}{d\lambda} \frac{dx^\nu}{d\lambda} = 0
  \]

  which ensures the motion remains consistent with the geodesic equation.

---

## **Final Answer:**
The mass term cancels in the geodesic equation because:
1. The **Euler-Lagrange formulation** of the action naturally removes the mass after differentiation.
2. The equation is **invariant under affine reparameterization**.
3. The **equivalence principle** ensures all objects move along the same geodesics, regardless of mass.

Thus, the geodesic equation applies **equally** to **all** particles, whether massive or massless.
```